### PR TITLE
chore: ignore vscode history folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 build/
 .vscode/
+.history/
 .idea
 *.log
 src_old


### PR DESCRIPTION
I hate almost accidentally commiting my VS code history.